### PR TITLE
fix: bump node version to latest supported

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -6,5 +6,5 @@ inputs:
     required: false
     default: latest
 runs:
-  using: node20
+  using: node24
   main: dist/setup-temporal/index.js


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->
Moved runner to `node24` since `node20` was [removed](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

This is what it's actually running on now, so this avoids the message.

<img width="1487" height="171" alt="image" src="https://github.com/user-attachments/assets/218dbb01-3b70-4f0a-82c6-314f3b083222" />


## Why?
<!-- Tell your future self why have you made these changes -->

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
