### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @temporalio/act


### PR DESCRIPTION
## Summary

- Adds `.github/CODEOWNERS` assigning `@temporalio/act` as owner for all files
- Consistent with the pattern used in other Temporal repos (e.g. `temporalio/cli`)

## Test plan

- [ ] Verify `@temporalio/act` is auto-requested for review on future PRs